### PR TITLE
Align environment templates

### DIFF
--- a/config_template.env
+++ b/config_template.env
@@ -160,4 +160,4 @@ CHROMA_PORT=8000
 LANGCHAIN_API_KEY=your-langsmith-api-key-here
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_PROJECT=background-agents-system
-LANGCHAIN_TRACING_V2=true 
+LANGCHAIN_TRACING_V2=true

--- a/env.example
+++ b/env.example
@@ -13,11 +13,11 @@ POSTGRESQL_TIMEOUT=30
 OPENAI_API_KEY=your-openai-api-key-here
 OPENAI_MODEL=gpt-4
 OPENAI_TEMPERATURE=0.7
-OPENAI_MAX_TOKENS=1000
+OPENAI_MAX_TOKENS=2000
 
 # LangSmith Configuration (Optional)
 LANGSMITH_API_KEY=your-langsmith-api-key-here
-LANGSMITH_PROJECT=background-agents
+LANGSMITH_PROJECT=background-agents-system
 LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_TRACING=true
 LANGSMITH_TIMEOUT=30
@@ -62,7 +62,7 @@ LOGS_DIR=logs
 TEMP_DIR=temp
 
 # Security Configuration
-SECRET_KEY=your-secret-key-here
+SECRET_KEY=your-secret-key-change-this-in-production
 CORS_ENABLED=true
 API_KEY_HEADER=X-API-Key
 CORS_ORIGINS=http://localhost:3000,http://localhost:8501
@@ -77,19 +77,15 @@ DASHBOARD_REFRESH_INTERVAL=30
 ALERT_EMAIL_ENABLED=false
 ALERT_EMAIL_SMTP_HOST=smtp.gmail.com
 ALERT_EMAIL_SMTP_PORT=587
-ALERT_EMAIL_USER=system@yourcompany.com
+ALERT_EMAIL_USER=your-alert-email@domain.com
 ALERT_EMAIL_PASSWORD=your-email-password
 ALERT_EMAIL_TO=admin@yourdomain.com
 
 # Backup Configuration
 BACKUP_ENABLED=true
 BACKUP_INTERVAL=daily
-BACKUP_RETENTION_DAYS=7
-BACKUP_LOCATION=./backups
-
-# Performance Tuning
-PERFORMANCE_POOL_TIMEOUT=30
-PERFORMANCE_POOL_RECYCLE=3600
+BACKUP_RETENTION_DAYS=30
+BACKUP_LOCATION=backups
 
 # Development Settings
 DEV_MODE=false
@@ -118,10 +114,3 @@ LANGCHAIN_API_KEY=your-langsmith-api-key-here
 LANGCHAIN_ENDPOINT=https://api.smith.langchain.com
 LANGCHAIN_PROJECT=background-agents-system
 LANGCHAIN_TRACING_V2=true
-
-# Feature Flags
-FEATURE_AI_HELP=true
-FEATURE_PERFORMANCE_MONITORING=true
-FEATURE_SELF_HEALING=true
-FEATURE_LANGSMITH_INTEGRATION=true
-FEATURE_ADVANCED_ANALYTICS=true 


### PR DESCRIPTION
## Summary
- sync defaults between `env.example` and `config_template.env`
- remove unused extras from `env.example`
- tidy trailing whitespace in template

## Testing
- `python test_postgresql_migration.py` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_686cbab280988324832d986b880c610a